### PR TITLE
Remove hard coded ntp servers in configuration file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,12 @@
 #
 
 # list of server
-ntp_servers: []
+ntp_servers:
+ - 0.ubuntu.pool.ntp.org
+ - 1.ubuntu.pool.ntp.org
+ - 2.ubuntu.pool.ntp.org
+ - 3.ubuntu.pool.ntp.org
+ - ntp.ubuntu.com
 # start on boot
 ntp_service_enabled: yes
 # current state: started, stopped

--- a/templates/etc-ntp.conf.j2
+++ b/templates/etc-ntp.conf.j2
@@ -15,17 +15,6 @@ filegen clockstats file clockstats type day enable
 server {{ value }}
 {% endfor %}
 
-# Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board
-# on 2011-02-08 (LP: #104525). See http://www.pool.ntp.org/join.html for
-# more information.
-server 0.ubuntu.pool.ntp.org
-server 1.ubuntu.pool.ntp.org
-server 2.ubuntu.pool.ntp.org
-server 3.ubuntu.pool.ntp.org
-
-# Use Ubuntu's ntp server as a fallback.
-server ntp.ubuntu.com
-
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
 # details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>
 # might also be helpful.


### PR DESCRIPTION
Because its not always appropriate to be using pool servers (security
concerns, network reliability, aggressive perimeter firewalling) I have
removed the default Ubuntu related server entries.

To ensure the role keeps working OOTB I've made them the default NTP
servers for the role.

This does mean instead of ntp_servers+5 defaults you only have ntp_servers, I'm not sure if this will be a deal breaker or not.
